### PR TITLE
Add Support for AWS Cost Explorer's withGroupBy Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ AWS Cost Explorer Cost and Usage Report
 - **access_key_id**: AWS Access Key Id (integer, required)
 - **secret_access_key**: AWS Secrete Access Key (string, default: `myvalue`)
 - **metrics**: metrics of the report (`AmortizedCost` `BlendedCost` `NetAmortizedCost` `NetUnblendedCost` `NormalizedUsageAmount` `UnblendedCost` `UsageQuantity`, default: `UnblendedCost`)
+- **groups**: grouping of costs by up to two different groups, either dimensions, tag keys, cost categories, or any two group by types (optional)
+    - **type**: valid values `DIMENSION` `TAG` `COST_CATEGORY` (string, required)
+    - **key**: valid values for the `DIMENSION` type
+      are `AZ` `INSTANCE_TYPE` `LEGAL_ENTITY_NAME` `INVOICING_ENTITY` `LINKED_ACCOUNT` `OPERATION` `PLATFORM` `PURCHASE_TYPE` `SERVICE` `TENANCY` `RECORD_TYPE` and `USAGE_TYPE`
+      (string, required)
 - **start_date**: start date of the report (string, required, format: `2020-01-01`)
 - **end_date**: end date of the report (string, required, format: `2020-01-01`)
 
@@ -25,6 +30,11 @@ in:
   access_key_id: xxx
   secret_access_key: yyy
   metrics: UnblendedCost
+  groups:
+    - type: DIMENSION
+      key: USAGE_TYPE
+    - type: TAG
+      key: Environment
   start_date: "2020-04-01"
   end_date: "2020-04-20"
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ configurations {
     provided
 }
 
-version = "0.0.4"
+version = "0.0.5"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.8
 dependencies {
     compile "org.embulk:embulk-core:0.9.23"
     provided "org.embulk:embulk-core:0.9.23"
-    compile "com.amazonaws:aws-java-sdk-costexplorer:1.11.772"
+    compile "com.amazonaws:aws-java-sdk-costexplorer:1.12.666"
     testCompile "junit:junit:4.+"
 }
 

--- a/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
@@ -29,6 +29,7 @@ import org.embulk.spi.type.Types;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Map;
 
 public class AwsCostExplorerInputPlugin
         implements InputPlugin
@@ -48,6 +49,10 @@ public class AwsCostExplorerInputPlugin
         @ConfigDefault("\"UnblendedCost\"")
         String getMetrics();
 
+        @Config("groups")
+        @ConfigDefault("[]")
+        List<Map<String, String>> getGroups();
+
         @Config("start_date")
         String getStartDate();
 
@@ -59,6 +64,8 @@ public class AwsCostExplorerInputPlugin
     public ConfigDiff transaction(final ConfigSource config, final InputPlugin.Control control)
     {
         final PluginTask task = config.loadConfig(PluginTask.class);
+
+        GroupsConfigValidator.validate(task.getGroups());
 
         ImmutableList.Builder<Column> columns = ImmutableList.builder();
 

--- a/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
@@ -1,5 +1,6 @@
 package org.embulk.input.aws_cost_explorer;
 
+import com.amazonaws.services.costexplorer.model.GetCostAndUsageRequest;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -10,7 +11,6 @@ import org.embulk.config.TaskSource;
 import org.embulk.input.aws_cost_explorer.client.AwsCostExplorerClient;
 import org.embulk.input.aws_cost_explorer.client.AwsCostExplorerClientFactory;
 import org.embulk.input.aws_cost_explorer.client.AwsCostExplorerRequestParametersFactory;
-import org.embulk.input.aws_cost_explorer.client.AwsCostExplorerResponse;
 import org.embulk.spi.Exec;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.PageBuilder;
@@ -104,12 +104,11 @@ public class AwsCostExplorerInputPlugin
             final PageOutput output)
     {
         final PluginTask task = taskSource.loadTask(PluginTask.class);
-
         final AwsCostExplorerClient awsCostExplorerClient = AwsCostExplorerClientFactory.create(task);
-        final AwsCostExplorerResponse awsCostExplorerResponse = awsCostExplorerClient.request(AwsCostExplorerRequestParametersFactory.create(task));
+        final GetCostAndUsageRequest requestParameters = AwsCostExplorerRequestParametersFactory.create(task);
 
         try (final PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
-            awsCostExplorerResponse.addRecordsToPage(pageBuilder, task);
+            awsCostExplorerClient.requestAll(requestParameters).forEach(response -> response.addRecordsToPage(pageBuilder, task));
             pageBuilder.finish();
         }
 

--- a/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
@@ -1,9 +1,6 @@
 package org.embulk.input.aws_cost_explorer;
 
-import java.util.List;
-
 import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.costexplorer.AWSCostExplorer;
@@ -13,9 +10,7 @@ import com.amazonaws.services.costexplorer.model.GetCostAndUsageRequest;
 import com.amazonaws.services.costexplorer.model.GetCostAndUsageResult;
 import com.amazonaws.services.costexplorer.model.Granularity;
 import com.amazonaws.services.costexplorer.model.MetricValue;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -33,27 +28,31 @@ import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Types;
 import org.slf4j.Logger;
 
-public class AwsCostExplorerInputPlugin implements InputPlugin
+import java.util.List;
+
+public class AwsCostExplorerInputPlugin
+        implements InputPlugin
 {
     protected final Logger logger = Exec.getLogger(getClass());
 
-    public interface PluginTask extends Task
+    public interface PluginTask
+            extends Task
     {
         @Config("access_key_id")
-        public String getAccessKeyId();
+        String getAccessKeyId();
 
         @Config("secret_access_key")
-        public String getSecretAccessKey();
+        String getSecretAccessKey();
 
         @Config("metrics")
         @ConfigDefault("\"UnblendedCost\"")
-        public String getMetrics();
+        String getMetrics();
 
         @Config("start_date")
-        public String getStartDate();
+        String getStartDate();
 
         @Config("end_date")
-        public String getEndDate();
+        String getEndDate();
     }
 
     @Override
@@ -78,7 +77,7 @@ public class AwsCostExplorerInputPlugin implements InputPlugin
 
     @Override
     public ConfigDiff resume(final TaskSource taskSource, final Schema schema, final int taskCount,
-                             final InputPlugin.Control control)
+            final InputPlugin.Control control)
     {
         control.run(taskSource, schema, taskCount);
         return Exec.newConfigDiff();
@@ -86,13 +85,13 @@ public class AwsCostExplorerInputPlugin implements InputPlugin
 
     @Override
     public void cleanup(final TaskSource taskSource, final Schema schema, final int taskCount,
-                        final List<TaskReport> successTaskReports)
+            final List<TaskReport> successTaskReports)
     {
     }
 
     @Override
     public TaskReport run(final TaskSource taskSource, final Schema schema, final int taskIndex,
-                          final PageOutput output)
+            final PageOutput output)
     {
         final PluginTask task = taskSource.loadTask(PluginTask.class);
 
@@ -110,7 +109,7 @@ public class AwsCostExplorerInputPlugin implements InputPlugin
         try (final PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
             result.getResultsByTime().forEach(resultsByTime -> {
                 System.out.println(resultsByTime.toString());
-                logger.info("Cost Explorer API results: {}", resultsByTime.toString());
+                logger.info("Cost Explorer API results: {}", resultsByTime);
                 String start = resultsByTime.getTimePeriod().getStart();
                 String end = resultsByTime.getTimePeriod().getEnd();
                 pageBuilder.setTimestamp(schema.getColumn(0), parser.parse(start));

--- a/src/main/java/org/embulk/input/aws_cost_explorer/GroupsConfigValidator.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/GroupsConfigValidator.java
@@ -1,0 +1,102 @@
+package org.embulk.input.aws_cost_explorer;
+
+import com.amazonaws.services.costexplorer.model.Dimension;
+import com.amazonaws.services.costexplorer.model.GroupDefinitionType;
+import org.embulk.config.ConfigException;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class GroupsConfigValidator
+{
+    private GroupsConfigValidator()
+    {
+    }
+
+    /**
+     * Validates the groups configuration.
+     *
+     * @param groups the groups configuration
+     */
+    public static void validate(List<Map<String, String>> groups)
+    {
+        if (groups.isEmpty()) {
+            return;
+        }
+
+        if (groups.size() > 2) {
+            throw new ConfigException("groups must have at most 2 elements.");
+        }
+
+        for (Map<String, String> group : groups) {
+            validateGroup(group);
+        }
+
+        validateDuplicateGroups(groups);
+    }
+
+    private static void validateGroup(Map<String, String> group)
+    {
+        final String groupType = group.get("type");
+        final String groupKey = group.get("key");
+
+        if (groupType == null || groupKey == null) {
+            throw new ConfigException("group must have a type and a key.");
+        }
+
+        if (GroupDefinitionType.DIMENSION.name().equals(groupType)) {
+            validateDimensionGroupKey(groupKey);
+            return;
+        }
+
+        for (GroupDefinitionType enumEntry : GroupDefinitionType.values()) {
+            if (enumEntry.toString().equals(groupType)) {
+                validateGroupKey(groupKey);
+                return;
+            }
+        }
+
+        throw new ConfigException("group type must be one of the following: "
+                + Arrays.stream(GroupDefinitionType.values()).map(Enum::name).collect(Collectors.joining(", ")));
+    }
+
+    private static void validateDimensionGroupKey(String groupKey)
+    {
+        for (Dimension enumEntry : Dimension.values()) {
+            if (enumEntry.name().equals(groupKey)) {
+                return;
+            }
+        }
+
+        throw new ConfigException("dimension group key must be one of the following: "
+                + Arrays.stream(Dimension.values()).map(Enum::name).collect(Collectors.joining(", ")));
+    }
+
+    private static void validateGroupKey(String groupKey)
+    {
+        if (!groupKey.isEmpty() && groupKey.length() <= 1024) {
+            return;
+        }
+
+        throw new ConfigException("group key must be non-empty and at most 1024 characters long.");
+    }
+
+    private static void validateDuplicateGroups(List<Map<String, String>> groups)
+    {
+        Set<String> typeAndKeyPairs = new HashSet<>();
+
+        for (Map<String, String> group : groups) {
+            String type = group.get("type");
+            String key = group.get("key");
+            String pair = type + ":" + key;
+
+            if (!typeAndKeyPairs.add(pair)) {
+                throw new ConfigException("groups must not have duplicate type and key pairs.");
+            }
+        }
+    }
+}

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClient.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClient.java
@@ -2,29 +2,87 @@ package org.embulk.input.aws_cost_explorer.client;
 
 import com.amazonaws.services.costexplorer.AWSCostExplorer;
 import com.amazonaws.services.costexplorer.model.GetCostAndUsageRequest;
+import com.amazonaws.services.costexplorer.model.GetCostAndUsageResult;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class AwsCostExplorerClient
 {
     private final AWSCostExplorer client;
 
-    /**
-     * Constructor
-     *
-     * @param client AWS Cost Explorer client
-     */
     public AwsCostExplorerClient(AWSCostExplorer client)
     {
         this.client = client;
     }
 
     /**
-     * Request to AWS Cost Explorer
+     * Request all pages of the cost and usage data.
      *
-     * @param requestParameters Request parameters
-     * @return Response
+     * @param requestParameters The request parameters for the cost and usage data.
+     * @return A stream of the cost and usage data.
      */
-    public AwsCostExplorerResponse request(GetCostAndUsageRequest requestParameters)
+    public Stream<AwsCostExplorerResponse> requestAll(GetCostAndUsageRequest requestParameters)
     {
-        return new AwsCostExplorerResponse(client.getCostAndUsage(requestParameters));
+        return StreamSupport.stream(makeResponseIterator(requestParameters), false);
+    }
+
+    private Spliterator<AwsCostExplorerResponse> makeResponseIterator(GetCostAndUsageRequest requestParameters)
+    {
+        return new Spliterator<AwsCostExplorerResponse>()
+        {
+            boolean isFinished = false;
+
+            @Override
+            public boolean tryAdvance(Consumer<? super AwsCostExplorerResponse> action)
+            {
+                if (isFinished) {
+                    return false;
+                }
+
+                final AwsCostExplorerResponse response = request(requestParameters);
+                action.accept(response);
+
+                prepareNextRequest(response);
+
+                return !isFinished;
+            }
+
+            private AwsCostExplorerResponse request(GetCostAndUsageRequest requestParameters)
+            {
+                final GetCostAndUsageResult result = client.getCostAndUsage(requestParameters);
+                return new AwsCostExplorerResponse(result);
+            }
+
+            private void prepareNextRequest(AwsCostExplorerResponse response)
+            {
+                final String nextPageToken = response.getNextPageToken();
+                requestParameters.setNextPageToken(nextPageToken);
+
+                if (nextPageToken == null || nextPageToken.isEmpty()) {
+                    isFinished = true;
+                }
+            }
+
+            @Override
+            public Spliterator<AwsCostExplorerResponse> trySplit()
+            {
+                return null; // Parallel processing is not supported.
+            }
+
+            @Override
+            public long estimateSize()
+            {
+                return Long.MAX_VALUE; // Size is unknown in advance.
+            }
+
+            @Override
+            public int characteristics()
+            {
+                return Spliterator.NONNULL | Spliterator.IMMUTABLE;
+            }
+        };
     }
 }

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClient.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClient.java
@@ -1,0 +1,30 @@
+package org.embulk.input.aws_cost_explorer.client;
+
+import com.amazonaws.services.costexplorer.AWSCostExplorer;
+import com.amazonaws.services.costexplorer.model.GetCostAndUsageRequest;
+
+public class AwsCostExplorerClient
+{
+    private final AWSCostExplorer client;
+
+    /**
+     * Constructor
+     *
+     * @param client AWS Cost Explorer client
+     */
+    public AwsCostExplorerClient(AWSCostExplorer client)
+    {
+        this.client = client;
+    }
+
+    /**
+     * Request to AWS Cost Explorer
+     *
+     * @param requestParameters Request parameters
+     * @return Response
+     */
+    public AwsCostExplorerResponse request(GetCostAndUsageRequest requestParameters)
+    {
+        return new AwsCostExplorerResponse(client.getCostAndUsage(requestParameters));
+    }
+}

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClient.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClient.java
@@ -33,37 +33,22 @@ public class AwsCostExplorerClient
     {
         return new Spliterator<AwsCostExplorerResponse>()
         {
-            boolean isFinished = false;
-
             @Override
             public boolean tryAdvance(Consumer<? super AwsCostExplorerResponse> action)
             {
-                if (isFinished) {
-                    return false;
-                }
-
                 final AwsCostExplorerResponse response = request(requestParameters);
                 action.accept(response);
 
-                prepareNextRequest(response);
+                final String nextPageToken = response.getNextPageToken();
+                requestParameters.setNextPageToken(nextPageToken);
 
-                return !isFinished;
+                return nextPageToken != null && !nextPageToken.isEmpty();
             }
 
             private AwsCostExplorerResponse request(GetCostAndUsageRequest requestParameters)
             {
                 final GetCostAndUsageResult result = client.getCostAndUsage(requestParameters);
                 return new AwsCostExplorerResponse(result);
-            }
-
-            private void prepareNextRequest(AwsCostExplorerResponse response)
-            {
-                final String nextPageToken = response.getNextPageToken();
-                requestParameters.setNextPageToken(nextPageToken);
-
-                if (nextPageToken == null || nextPageToken.isEmpty()) {
-                    isFinished = true;
-                }
             }
 
             @Override

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClientFactory.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClientFactory.java
@@ -1,0 +1,43 @@
+package org.embulk.input.aws_cost_explorer.client;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.costexplorer.AWSCostExplorer;
+import com.amazonaws.services.costexplorer.AWSCostExplorerClientBuilder;
+import org.embulk.input.aws_cost_explorer.AwsCostExplorerInputPlugin.PluginTask;
+
+public class AwsCostExplorerClientFactory
+{
+    private static final String REGION = "us-east-1";
+
+    private AwsCostExplorerClientFactory()
+    {
+    }
+
+    /**
+     * Create a new AwsCostExplorerClient instance.
+     *
+     * @param task PluginTask
+     * @return AwsCostExplorerClient
+     */
+    public static AwsCostExplorerClient create(PluginTask task)
+    {
+        final AWSCostExplorer client = AWSCostExplorerClientBuilder
+                .standard()
+                .withRegion(REGION)
+                .withCredentials(createAWSStaticCredentialsProvider(task))
+                .build();
+
+        return new AwsCostExplorerClient(client);
+    }
+
+    private static AWSStaticCredentialsProvider createAWSStaticCredentialsProvider(PluginTask task)
+    {
+        final BasicAWSCredentials credentials = new BasicAWSCredentials(
+                task.getAccessKeyId(),
+                task.getSecretAccessKey()
+        );
+
+        return new AWSStaticCredentialsProvider(credentials);
+    }
+}

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerRequestParametersFactory.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerRequestParametersFactory.java
@@ -1,0 +1,59 @@
+package org.embulk.input.aws_cost_explorer.client;
+
+import com.amazonaws.services.costexplorer.model.DateInterval;
+import com.amazonaws.services.costexplorer.model.GetCostAndUsageRequest;
+import com.amazonaws.services.costexplorer.model.Granularity;
+import com.amazonaws.services.costexplorer.model.GroupDefinition;
+import org.embulk.input.aws_cost_explorer.AwsCostExplorerInputPlugin.PluginTask;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class AwsCostExplorerRequestParametersFactory
+{
+    private AwsCostExplorerRequestParametersFactory()
+    {
+    }
+
+    /**
+     * Create a GetCostAndUsageRequest object from the PluginTask object.
+     *
+     * @param task PluginTask object
+     * @return GetCostAndUsageRequest object
+     */
+    public static GetCostAndUsageRequest create(PluginTask task)
+    {
+        GetCostAndUsageRequest request = new GetCostAndUsageRequest()
+                .withTimePeriod(new DateInterval().withStart(task.getStartDate()).withEnd(task.getEndDate()))
+                .withGranularity(Granularity.DAILY)
+                .withMetrics(task.getMetrics());
+
+        final List<GroupDefinition> groups = createGroupDefinitionList(task.getGroups());
+        if (!groups.isEmpty()) {
+            request.withGroupBy(groups);
+        }
+
+        return request;
+    }
+
+    private static List<GroupDefinition> createGroupDefinitionList(List<Map<String, String>> groups)
+    {
+        ArrayList<GroupDefinition> groupDefinitionList = new ArrayList<>();
+
+        for (Map<String, String> group : groups) {
+            groupDefinitionList.add(createGroupDefinition(group.get("type"), group.get("key")));
+        }
+
+        return groupDefinitionList;
+    }
+
+    private static GroupDefinition createGroupDefinition(String groupType, String groupKey)
+    {
+        final GroupDefinition group = new GroupDefinition();
+        group.setType(groupType);
+        group.setKey(groupKey);
+
+        return group;
+    }
+}

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerResponse.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerResponse.java
@@ -62,6 +62,12 @@ public class AwsCostExplorerResponse
         pageBuilder.setTimestamp(schema.getColumn(i++), timePeriodStart);
         pageBuilder.setTimestamp(schema.getColumn(i++), timePeriodEnd);
         pageBuilder.setString(schema.getColumn(i++), task.getMetrics());
+
+        for (int j = 0; j < task.getGroups().size(); j++) {
+            // Fill with empty strings for periods with no records, as groups will be empty arrays for these periods.
+            pageBuilder.setString(schema.getColumn(i++), "");
+        }
+
         pageBuilder.setDouble(schema.getColumn(i++), Double.parseDouble(metricValue.getAmount()));
         pageBuilder.setString(schema.getColumn(i++), metricValue.getUnit());
         pageBuilder.setBoolean(schema.getColumn(i), resultsByTime.isEstimated());

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerResponse.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerResponse.java
@@ -1,0 +1,98 @@
+package org.embulk.input.aws_cost_explorer.client;
+
+import com.amazonaws.services.costexplorer.model.GetCostAndUsageResult;
+import com.amazonaws.services.costexplorer.model.MetricValue;
+import com.amazonaws.services.costexplorer.model.ResultByTime;
+import org.embulk.input.aws_cost_explorer.AwsCostExplorerInputPlugin.PluginTask;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.Schema;
+import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.time.TimestampParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AwsCostExplorerResponse
+{
+    private final GetCostAndUsageResult result;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final TimestampParser timestampParser = TimestampParser.of("%Y-%m-%d", "UTC");
+
+    /**
+     * Constructor
+     *
+     * @param result GetCostAndUsageResult
+     */
+    public AwsCostExplorerResponse(GetCostAndUsageResult result)
+    {
+        this.result = result;
+    }
+
+    /**
+     * Add records to page
+     *
+     * @param pageBuilder PageBuilder
+     * @param task PluginTask
+     */
+    public void addRecordsToPage(PageBuilder pageBuilder, PluginTask task)
+    {
+        result.getResultsByTime().forEach(resultsByTime -> {
+            System.out.println(resultsByTime.toString());
+            logger.info("Cost Explorer API results: {}", resultsByTime);
+
+            if (resultsByTime.getGroups().isEmpty()) {
+                addRecordToPageWithoutGroupBy(pageBuilder, task, resultsByTime);
+            }
+            else {
+                addRecordsToPageWithGroupBy(pageBuilder, task, resultsByTime);
+            }
+        });
+    }
+
+    private void addRecordToPageWithoutGroupBy(PageBuilder pageBuilder, PluginTask task, ResultByTime resultsByTime)
+    {
+        final Schema schema = pageBuilder.getSchema();
+
+        Timestamp timePeriodStart = timestampParser.parse(resultsByTime.getTimePeriod().getStart());
+        Timestamp timePeriodEnd = timestampParser.parse(resultsByTime.getTimePeriod().getEnd());
+        MetricValue metricValue = resultsByTime.getTotal().get(task.getMetrics());
+
+        int i = 0;
+        pageBuilder.setTimestamp(schema.getColumn(i++), timePeriodStart);
+        pageBuilder.setTimestamp(schema.getColumn(i++), timePeriodEnd);
+        pageBuilder.setString(schema.getColumn(i++), task.getMetrics());
+        pageBuilder.setDouble(schema.getColumn(i++), Double.parseDouble(metricValue.getAmount()));
+        pageBuilder.setString(schema.getColumn(i++), metricValue.getUnit());
+        pageBuilder.setBoolean(schema.getColumn(i), resultsByTime.isEstimated());
+
+        pageBuilder.addRecord();
+    }
+
+    private void addRecordsToPageWithGroupBy(PageBuilder pageBuilder, PluginTask task, ResultByTime resultsByTime)
+    {
+        final Schema schema = pageBuilder.getSchema();
+
+        Timestamp timePeriodStart = timestampParser.parse(resultsByTime.getTimePeriod().getStart());
+        Timestamp timePeriodEnd = timestampParser.parse(resultsByTime.getTimePeriod().getEnd());
+
+        resultsByTime.getGroups().forEach(group -> {
+            MetricValue metricValue = group.getMetrics().get(task.getMetrics());
+            int i = 0;
+
+            pageBuilder.setTimestamp(schema.getColumn(i++), timePeriodStart);
+            pageBuilder.setTimestamp(schema.getColumn(i++), timePeriodEnd);
+            pageBuilder.setString(schema.getColumn(i++), task.getMetrics());
+
+            for (String key : group.getKeys()) {
+                pageBuilder.setString(schema.getColumn(i++), key);
+            }
+
+            pageBuilder.setDouble(schema.getColumn(i++), Double.parseDouble(metricValue.getAmount()));
+            pageBuilder.setString(schema.getColumn(i++), metricValue.getUnit());
+            pageBuilder.setBoolean(schema.getColumn(i), resultsByTime.isEstimated());
+
+            pageBuilder.addRecord();
+        });
+    }
+}

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerResponse.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerResponse.java
@@ -30,6 +30,14 @@ public class AwsCostExplorerResponse
     }
 
     /**
+     * Get next page token
+     */
+    public String getNextPageToken()
+    {
+        return result.getNextPageToken();
+    }
+
+    /**
      * Add records to page
      *
      * @param pageBuilder PageBuilder


### PR DESCRIPTION
This pull request adds withGroupBy support from AWS Cost Explorer and adds pagination support.

**Key Highlights:**

- Added `withGroupBy` support for AWS Cost Explorer.
- Implemented pagination support.

**Additional Improvements:**

- Handled empty array responses for groups with `withGroupBy`.
- Updated plugin version to 0.0.5.
- Updated plugin documentation.
- Dynamic addition of `group_key1` and `group_key2` columns when `withGroupBy` is specified.
- Added configuration options and validations for groups.
- Updated `aws-java-sdk-costexplorer` to version 1.12.666.
- Performed code cleanup.