### PR TITLE
bump aws sdk to v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,17 @@ dependencies {
 
     compile "org.embulk:embulk-util-config:0.3.4"
     compile "org.embulk:embulk-util-timestamp:0.2.2"
-    compile "com.amazonaws:aws-java-sdk-costexplorer:1.12.666"
+    compile "software.amazon.awssdk:costexplorer:2.20.26"
+    compile "software.amazon.awssdk:auth:2.20.26"
+    compile "software.amazon.awssdk:apache-client:2.20.26"
 
     testImplementation "junit:junit:4.+"
     testImplementation "org.embulk:embulk-core:${embulkVersion}"
     testImplementation "org.embulk:embulk-deps:${embulkVersion}"
     testImplementation "org.embulk:embulk-junit4:${embulkVersion}"
     testImplementation "org.mockito:mockito-core:3.12.4"
+    testImplementation "javax.xml.bind:jaxb-api:2.3.1"
+    testImplementation "org.glassfish.jaxb:jaxb-runtime:2.3.1"
 }
 
 embulkPlugin {

--- a/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/AwsCostExplorerInputPlugin.java
@@ -1,6 +1,5 @@
 package org.embulk.input.aws_cost_explorer;
 
-import com.amazonaws.services.costexplorer.model.GetCostAndUsageRequest;
 import java.util.List;
 import java.util.Map;
 import org.embulk.config.ConfigDiff;
@@ -19,6 +18,7 @@ import org.embulk.spi.type.Types;
 import org.embulk.util.config.ConfigMapper;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.TaskMapper;
+import software.amazon.awssdk.services.costexplorer.model.GetCostAndUsageRequest;
 
 public class AwsCostExplorerInputPlugin
         implements InputPlugin

--- a/src/main/java/org/embulk/input/aws_cost_explorer/GroupsConfigValidator.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/GroupsConfigValidator.java
@@ -1,7 +1,5 @@
 package org.embulk.input.aws_cost_explorer;
 
-import com.amazonaws.services.costexplorer.model.Dimension;
-import com.amazonaws.services.costexplorer.model.GroupDefinitionType;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -9,6 +7,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.embulk.config.ConfigException;
+import software.amazon.awssdk.services.costexplorer.model.Dimension;
+import software.amazon.awssdk.services.costexplorer.model.GroupDefinitionType;
 
 public class GroupsConfigValidator
 {

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClientFactory.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerClientFactory.java
@@ -1,14 +1,14 @@
 package org.embulk.input.aws_cost_explorer.client;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.costexplorer.AWSCostExplorer;
-import com.amazonaws.services.costexplorer.AWSCostExplorerClientBuilder;
 import org.embulk.input.aws_cost_explorer.PluginTask;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 
 public class AwsCostExplorerClientFactory
 {
-    private static final String REGION = "us-east-1";
+    private static final Region REGION = Region.US_EAST_1;
 
     private AwsCostExplorerClientFactory()
     {
@@ -22,22 +22,21 @@ public class AwsCostExplorerClientFactory
      */
     public static AwsCostExplorerClient create(PluginTask task)
     {
-        final AWSCostExplorer client = AWSCostExplorerClientBuilder
-                .standard()
-                .withRegion(REGION)
-                .withCredentials(createAWSStaticCredentialsProvider(task))
+        final CostExplorerClient client = CostExplorerClient.builder()
+                .region(REGION)
+                .credentialsProvider(createStaticCredentialsProvider(task))
                 .build();
 
         return new AwsCostExplorerClient(client);
     }
 
-    private static AWSStaticCredentialsProvider createAWSStaticCredentialsProvider(PluginTask task)
+    private static StaticCredentialsProvider createStaticCredentialsProvider(PluginTask task)
     {
-        final BasicAWSCredentials credentials = new BasicAWSCredentials(
+        final AwsBasicCredentials credentials = AwsBasicCredentials.create(
                 task.getAccessKeyId(),
                 task.getSecretAccessKey()
         );
 
-        return new AWSStaticCredentialsProvider(credentials);
+        return StaticCredentialsProvider.create(credentials);
     }
 }

--- a/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerRequestParametersFactory.java
+++ b/src/main/java/org/embulk/input/aws_cost_explorer/client/AwsCostExplorerRequestParametersFactory.java
@@ -1,13 +1,13 @@
 package org.embulk.input.aws_cost_explorer.client;
 
-import com.amazonaws.services.costexplorer.model.DateInterval;
-import com.amazonaws.services.costexplorer.model.GetCostAndUsageRequest;
-import com.amazonaws.services.costexplorer.model.Granularity;
-import com.amazonaws.services.costexplorer.model.GroupDefinition;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.embulk.input.aws_cost_explorer.PluginTask;
+import software.amazon.awssdk.services.costexplorer.model.DateInterval;
+import software.amazon.awssdk.services.costexplorer.model.GetCostAndUsageRequest;
+import software.amazon.awssdk.services.costexplorer.model.Granularity;
+import software.amazon.awssdk.services.costexplorer.model.GroupDefinition;
 
 public class AwsCostExplorerRequestParametersFactory
 {
@@ -23,17 +23,20 @@ public class AwsCostExplorerRequestParametersFactory
      */
     public static GetCostAndUsageRequest create(PluginTask task)
     {
-        GetCostAndUsageRequest request = new GetCostAndUsageRequest()
-                .withTimePeriod(new DateInterval().withStart(task.getStartDate()).withEnd(task.getEndDate()))
-                .withGranularity(Granularity.DAILY)
-                .withMetrics(task.getMetrics());
+        GetCostAndUsageRequest.Builder requestBuilder = GetCostAndUsageRequest.builder()
+                .timePeriod(DateInterval.builder()
+                        .start(task.getStartDate())
+                        .end(task.getEndDate())
+                        .build())
+                .granularity(Granularity.DAILY)
+                .metrics(task.getMetrics());
 
         final List<GroupDefinition> groups = createGroupDefinitionList(task.getGroups());
         if (!groups.isEmpty()) {
-            request.withGroupBy(groups);
+            requestBuilder.groupBy(groups);
         }
 
-        return request;
+        return requestBuilder.build();
     }
 
     private static List<GroupDefinition> createGroupDefinitionList(List<Map<String, String>> groups)
@@ -49,10 +52,9 @@ public class AwsCostExplorerRequestParametersFactory
 
     private static GroupDefinition createGroupDefinition(String groupType, String groupKey)
     {
-        final GroupDefinition group = new GroupDefinition();
-        group.setType(groupType);
-        group.setKey(groupKey);
-
-        return group;
+        return GroupDefinition.builder()
+                .type(groupType)
+                .key(groupKey)
+                .build();
     }
 }


### PR DESCRIPTION
ref: https://aws.amazon.com/jp/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/

The AWS SDK for Java v1.x will enter maintenance mode on July 31, 2024, and reach end-of-support on December 31, 2025.