### PR TITLE
use JDK 8 to push gem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,10 +46,11 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.ref, 'refs/tags/') }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Ruby 2.7
-        uses: ruby/setup-ruby@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
         with:
-          ruby-version: 2.7
+          distribution: 'temurin'
+          java-version: 8
       - name: push gem
         uses: trocco-io/push-gem-to-gpr-action@v1
         with:


### PR DESCRIPTION
error cropped up while pushing gem...
```
General error during semantic analysis: Unsupported class file major version 61
``


https://github.com/trocco-io/embulk-input-aws_cost_explorer/actions/runs/19055739022/job/54425427641
